### PR TITLE
Fix version conflicts caused by PR#1026

### DIFF
--- a/src/Host/Host.csproj
+++ b/src/Host/Host.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
@@ -22,8 +22,8 @@
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Npgsql" Version="5.0.7" />
-    <PackageReference Include="Sentry" Version="3.8.2" />
-    <PackageReference Include="Sentry.AspNetCore" Version="3.8.2" />
+    <PackageReference Include="Sentry" Version="3.8.3" />
+    <PackageReference Include="Sentry.AspNetCore" Version="3.8.3" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Sentry.AspNetCore from 3.8.2 to 3.8.3. [(PR#1026)](https://github.com/montr/montr/pull/1026).
Hope this fix can help you.

Best regards,
sucrose